### PR TITLE
feat: Add concurrent processing to importer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     cmr-entity-resolution (0.1.0)
+      concurrent-ruby (~> 1.3)
       csv (~> 3.3)
       faraday (~> 2.7)
       faraday-retry (~> 2.3)

--- a/cmr-entity-resolution.gemspec
+++ b/cmr-entity-resolution.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'sequel', '~> 5.68'
   s.add_dependency 'thor', '~> 1.2'
   s.add_dependency 'yajl-ruby', '~> 1.4'
+  s.add_dependency 'concurrent-ruby', '~> 1.3'
 end

--- a/cmr-entity-resolution.gemspec
+++ b/cmr-entity-resolution.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.2'
 
   # Add runtime dependencies.
+  s.add_dependency 'concurrent-ruby', '~> 1.3'
   s.add_dependency 'csv', '~> 3.3'
   s.add_dependency 'faraday', '~> 2.7'
   s.add_dependency 'faraday-retry', '~> 2.3'
@@ -40,5 +41,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'sequel', '~> 5.68'
   s.add_dependency 'thor', '~> 1.2'
   s.add_dependency 'yajl-ruby', '~> 1.4'
-  s.add_dependency 'concurrent-ruby', '~> 1.3'
 end

--- a/docs/importing-exporting.md
+++ b/docs/importing-exporting.md
@@ -35,9 +35,9 @@ correct path of your configuration file to `--config`.
 
 #### Concurrency
 The importer processes records concurrently. You can control the number of threads:
-    - **CLI flag**: `--concurrency 8`
-    - **Environment variable**: `IMPORT_CONCURRENCY=8`
-    - **config.yml**: add top-level value such as `concurrency: 8`
+  - **CLI flag**: `--concurrency 8`
+  - **Environment variable**: `IMPORT_CONCURRENCY=8`
+  - **config.yml**: add top-level value such as `concurrency: 8`
 
 By default, the importer is configured for 4 threads.
 

--- a/docs/importing-exporting.md
+++ b/docs/importing-exporting.md
@@ -33,6 +33,14 @@ correct path of your configuration file to `--config`.
 ./bin/importer import --config config/config.yml
 ```
 
+#### Concurrency
+The importer processes records concurrently. You can control the number of threads:
+    - **CLI flag**: `--concurrency 8`
+    - **Environment variable**: `IMPORT_CONCURRENCY=8`
+    - **config.yml**: add top-level value such as `concurrency: 8`
+
+By default, the importer is configured for 4 threads.
+
 ### Exporter
 
 ```bash

--- a/exe/importer
+++ b/exe/importer
@@ -15,7 +15,7 @@ class Importer < Thor
 
   def import
     config = Config.from_file(options[:config])
-    config.concurrency = options[:concurrency] if options[:concurrency] # overide concurrency if provided
+    config.concurrency = options[:concurrency] if options[:concurrency] # override concurrency if provided
     import = Import.new(config)
     success = import.import
 

--- a/exe/importer
+++ b/exe/importer
@@ -9,10 +9,15 @@ class Importer < Thor
   desc 'import', 'Import data from a configured source into Senzing'
   option :config, desc: 'Path to the configuration file for this data set',
                  default: File.expand_path(File.join(__dir__, '../config/config.yml'))
+  option :concurrency, desc: 'Number of concurrent threads for import',
+                    type: :numeric,
+                    default: nil
+
   def import
     config = Config.from_file(options[:config])
+    config.concurrency = options[:concurrency] if options[:concurrency] # overide concurrency if provided
+    
     import = Import.new(config)
-
     success = import.import
 
     success ? say_status('success', 'Import complete!') : say_status('error', 'Import encountered errors.', :red)

--- a/exe/importer
+++ b/exe/importer
@@ -16,7 +16,6 @@ class Importer < Thor
   def import
     config = Config.from_file(options[:config])
     config.concurrency = options[:concurrency] if options[:concurrency] # overide concurrency if provided
-    
     import = Import.new(config)
     success = import.import
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -24,7 +24,7 @@ class Config
     end
   end
 
-  attr_accessor :destination, :field_map, :filters, :log_level, :logger,
+  attr_accessor :concurrency, :destination, :field_map, :filters, :log_level, :logger,
                 :match_level, :match_score, :senzing, :sources, :transformations
 
   def initialize
@@ -37,6 +37,7 @@ class Config
 
   # Set default configuration values.
   def defaults
+    @concurrency = ENV.fetch('IMPORT_CONCURRENCY', 4).to_i
     @destination = {}
     @field_map = []
     @filters = []

--- a/lib/import.rb
+++ b/lib/import.rb
@@ -69,7 +69,7 @@ class Import
   end
 
   def create_thread_pool
-    threads = (@config.respond_to?(:concurrency) && @config.concurrency) || 5
+    threads = (@config.respond_to?(:concurrency) && @config.concurrency) || 4
     Concurrent::ThreadPoolExecutor.new(
       min_threads: threads,
       max_threads: threads,

--- a/lib/import.rb
+++ b/lib/import.rb
@@ -34,23 +34,13 @@ class Import
   def import_from(source_name)
     raise SourceNotFound, "#{source_name} not found" unless @config.sources.key?(source_name)
 
-    source = sources[source_name]
-    @config.logger.info("Importing data from #{source.name} with #{@config.concurrency} threads")
-
     success = Concurrent::AtomicBoolean.new(true)
     pool = create_thread_pool
 
-    source.each do |record|
-      next unless filter(record)
-
-      transformed = transform(source, record)
-      pool.post do
-        process_record(transformed, success)
-      end
-    end
+    enqueue_source_records(sources[source_name], pool, success)
 
     pool.shutdown
-    pool.wait_for_termination(60) # timeout after 60 seconds
+    pool.wait_for_termination(60)
     success.value
   ensure
     pool&.kill if pool && !pool.shutdown?
@@ -58,22 +48,33 @@ class Import
 
   private
 
-  # Process a single record with error handling, catches exceptions
+  def enqueue_source_records(source, pool, success)
+    @config.logger.info("Importing data from #{source.name} with #{@config.concurrency} threads")
+    sleep 3
+
+    source.each do |record|
+      next unless filter(record)
+
+      transformed = transform(source, record)
+      pool.post { process_record(transformed, success) }
+    end
+  end
+
   def process_record(record, success)
     result = senzing.upsert_record(record)
     success.make_false unless result
   rescue StandardError => e
-    @config.logger.error("Failed to upsert record: #{e.message}") # log error
+    @config.logger.error("Failed to upsert record: #{e.class}: #{e.message}")
     success.make_false
   end
 
-  # Creates a new thread pool for each import_from call
   def create_thread_pool
+    threads = (@config.respond_to?(:concurrency) && @config.concurrency) || 5
     Concurrent::ThreadPoolExecutor.new(
-      min_threads: @config.concurrency,
-      max_threads: @config.concurrency,
-      max_queue: @config.concurrency * 2,  # backpressure, bounded queue (2x threads) 
-      fallback_policy: :caller_runs        
+      min_threads: threads,
+      max_threads: threads,
+      max_queue: threads * 2,
+      fallback_policy: :caller_runs
     )
   end
 
@@ -98,21 +99,6 @@ class Import
       yield loaded if block_given?
 
       [name, loaded]
-    end
-  end
-
-  def create_thread_pool
-    threads = (@config.respond_to?(:concurrency) && @config.concurrency) || 5
-    Concurrent::FixedThreadPool.new(threads)
-  end
-
-  def process_record(record, success)
-    begin
-      ok = senzing.upsert_record(record)
-      success.make_false unless ok
-    rescue => e
-      @config.logger.error("Error importing record: #{e.class}: #{e.message}")
-      success.make_false
     end
   end
 end

--- a/lib/import.rb
+++ b/lib/import.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'concurrent'
 require_relative 'filterable'
 require_relative 'senzing'
 require_relative 'source'
@@ -33,19 +34,48 @@ class Import
   def import_from(source_name)
     raise SourceNotFound, "#{source_name} not found" unless @config.sources.key?(source_name)
 
-    success = true
     source = sources[source_name]
-    @config.logger.info("Importing data from #{source.name}")
+    @config.logger.info("Importing data from #{source.name} with #{@config.concurrency} threads")
+
+    success = Concurrent::AtomicBoolean.new(true)
+    pool = create_thread_pool
+
     source.each do |record|
       next unless filter(record)
 
-      success &&= senzing.upsert_record(transform(source, record))
+      transformed = transform(source, record)
+      pool.post do
+        process_record(transformed, success)
+      end
     end
 
-    success
+    pool.shutdown
+    pool.wait_for_termination(60) # timeout after 60 seconds
+    success.value
+  ensure
+    pool&.kill if pool && !pool.shutdown?
   end
 
   private
+
+  # Process a single record with error handling, catches exceptions
+  def process_record(record, success)
+    result = senzing.upsert_record(record)
+    success.make_false unless result
+  rescue StandardError => e
+    @config.logger.error("Failed to upsert record: #{e.message}") # log error
+    success.make_false
+  end
+
+  # Creates a new thread pool for each import_from call
+  def create_thread_pool
+    Concurrent::ThreadPoolExecutor.new(
+      min_threads: @config.concurrency,
+      max_threads: @config.concurrency,
+      max_queue: @config.concurrency * 2,  # backpressure, bounded queue (2x threads) 
+      fallback_policy: :caller_runs        
+    )
+  end
 
   # Loads the Senzing client and proxies calls.
   #
@@ -68,6 +98,21 @@ class Import
       yield loaded if block_given?
 
       [name, loaded]
+    end
+  end
+
+  def create_thread_pool
+    threads = (@config.respond_to?(:concurrency) && @config.concurrency) || 5
+    Concurrent::FixedThreadPool.new(threads)
+  end
+
+  def process_record(record, success)
+    begin
+      ok = senzing.upsert_record(record)
+      success.make_false unless ok
+    rescue => e
+      @config.logger.error("Error importing record: #{e.class}: #{e.message}")
+      success.make_false
     end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -26,4 +26,18 @@ RSpec.describe Config do
       expect(from_file.sources).to include(:import)
     end
   end
+
+  describe '#defaults' do
+    describe 'concurrency' do
+      it 'defaults to 4' do
+        expect(described_class.new.concurrency).to eq(4)
+      end
+
+      it 'uses IMPORT_CONCURRENCY env variable' do
+        allow(ENV).to receive(:fetch).with('IMPORT_CONCURRENCY', anything).and_return(16)
+
+        expect(described_class.new.concurrency).to eq(16)
+      end
+    end
+  end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Config do
       end
 
       it 'uses IMPORT_CONCURRENCY env variable' do
-        allow(ENV).to receive(:fetch).with('IMPORT_CONCURRENCY', anything).and_return(16)
+        allow(ENV).to receive(:fetch).with('IMPORT_CONCURRENCY', anything).and_return('16')
 
         expect(described_class.new.concurrency).to eq(16)
       end

--- a/spec/unit/import_spec.rb
+++ b/spec/unit/import_spec.rb
@@ -92,4 +92,47 @@ RSpec.describe Import do
       let(:object) { senzing }
     end
   end
+
+  describe '#import_from (concurrency)' do
+    before do
+      allow(Source::CSV).to receive(:new).with(hash_including(name: :factory)).and_return(sources[:factory])
+      allow(Source::CSV).to receive(:new).with(hash_including(name: :test)).and_return(sources[:test])
+
+      allow(Senzing).to receive(:new).and_return(senzing)
+
+      allow(Filter).to receive(:filter).and_return(true)
+      allow(Transformation).to receive(:transform).and_return(record)
+    end
+
+    context 'when processing records' do
+      it 'returns true when all records succeed' do
+        allow(senzing).to receive(:upsert_record).and_return(true)
+
+        expect(import.import_from(:factory)).to be(true)
+      end
+
+      it 'returns false if any record fails' do
+        allow(senzing).to receive(:upsert_record).and_return(false)
+
+        expect(import.import_from(:factory)).to be(false)
+      end
+
+      it 'handles thread exceptions' do
+        allow(senzing).to receive(:upsert_record).and_raise(StandardError, 'API Error')
+        allow(config.logger).to receive(:error)
+
+        import.import_from(:factory)
+        expect(config.logger).to have_received(:error).with(/Failed to upsert record/)
+      end
+    end
+
+    it 'configures the thread pool correctly' do
+      allow(Concurrent::ThreadPoolExecutor).to receive(:new).and_call_original
+      allow(senzing).to receive(:upsert_record).and_return(true)
+
+      import.import_from(:factory)
+
+      expect(Concurrent::ThreadPoolExecutor).to have_received(:new).with(hash_including(fallback_policy: :caller_runs))
+    end
+  end
 end


### PR DESCRIPTION
# Summary
  - Add multi-threaded record processing to the importer using [concurrent-ruby](https://ruby-concurrency.github.io/concurrent-ruby/master/index.html)
  - Records are now processed in parallel via a thread pool, which may significantly improving importer performance in some circumstances
  - By default, will run with 4 threads but configurable via CLI flag (--concurrency), environment variable (IMPORT_CONCURRENCY), or yaml file


# Changes
  - lib/import.rb: Thread pool 
  - lib/config.rb, exe/importer: Add concurrency attribute with env var support
  - Tests: Coverage for config defaults, env var override, success/failure handling, and exception logging
  - Documentation (docs/importing-exporting.md): Document concurrency options
  
# Light Validation  
  - Run bundle exec rspec - all tests pass
  - `git clone -b concurrency https://github.com/codeforamerica/cmr-entity-resolution.git`
  - (`docker-compose build —no-cache`, `docker-compose up -d`, etc)
  `docker-compose up importer`
    - Should log 'INFO — : Importing data from courts with 4 threads` (default)
  - `docker-compose run -e IMPORT_CONCURRENCY=16 importer`
    - Should log 'INFO — : Importing data from courts with 16 threads`
    
  