### PR TITLE
fix: adds missing runtime dependencies if Debian 12+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,29 @@ RUN apt-get autoremove && apt-get clean
 
 FROM --platform=linux/amd64 ruby:${RUBY_VERSION:-3.3}
 
-# Copy the configurations from the senzingapi-runtime image.
+# Install runtime libraries required by Senzing
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libsqlite3-0 \
+      libpq5 \
+      libxml2 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Senzing requires libssl1.1, which is not available on Debian 12+ (using OpenSSL 3.x)
+# only install if not already present (Debian 11 includes by default)
+RUN if ! dpkg -s libssl1.1 > /dev/null 2>&1; then \
+      wget -q http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
+      dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
+      rm libssl1.1_1.1.1f-1ubuntu2_amd64.deb; \
+    fi
+
+# Copy the Senzing installation from Stage 1.
 COPY --from=configs /opt/senzing /opt/senzing
+
+# Create config directory from templates
+RUN mkdir -p /etc/opt/senzing && \
+    cp -R /opt/senzing/g2/resources/templates/* /etc/opt/senzing/
 
 # Install the cli tooling.
 COPY . /opt/cmr

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ RUN wget https://senzing-production-apt.s3.amazonaws.com/senzingrepo_2.0.0-1_all
     apt-get install -y "senzingapi=$SENZING_VERSION*" && \
     rm ./senzingrepo_2.0.0-1_all.deb
 
+
 # Clean up.
 RUN apt-get autoremove && apt-get clean
+
 
 FROM --platform=linux/amd64 ruby:${RUBY_VERSION:-3.3}
 
@@ -52,6 +54,9 @@ RUN if ! dpkg -s libssl1.1 > /dev/null 2>&1; then \
 
 # Copy the Senzing installation from Stage 1.
 COPY --from=configs /opt/senzing /opt/senzing
+
+# force current to point local 5.0.0 data folder
+RUN ln -sf /opt/senzing/data/[0-9]* /opt/senzing/data/current
 
 # Create config directory from templates
 RUN mkdir -p /etc/opt/senzing && \


### PR DESCRIPTION
# Add missing runtime dependencies

Issue: Senzing requires libssl1.1 (see [Using Debian 12 Linux](https://senzing.zendesk.com/hc/en-us/articles/115010259947-System-Requirements#01HBB40KYWKE8DTZNYR0X15DKW) )

This update includes multi-stage build that includes a conditional install that downloads libssl1.1 when not already present.